### PR TITLE
feat: add Trends page with weight/sleep/digestion charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "next-auth": "^5.0.0-beta.32",
         "prisma": "^6.19.3",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "recharts": "^3.0.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -1060,6 +1061,32 @@
         "@prisma/debug": "6.19.3"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
@@ -1329,6 +1356,12 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
     },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
@@ -1359,6 +1392,69 @@
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -1395,14 +1491,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1418,6 +1514,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.21.0",
@@ -2650,6 +2752,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2739,8 +2850,129 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2820,6 +3052,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3179,6 +3417,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -3700,6 +3949,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.4.0",
@@ -4296,6 +4551,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "11.1.16",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.16.tgz",
+      "integrity": "sha512-Xs7H9rBc+kti1J6RueUvbEBkmOz7jqj11XYgf+YMXAYzu8EeE7hwZ9poLXdVfVnGmJu7QAf41T7H2KuF6QoK6Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4355,6 +4620,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6247,8 +6521,30 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -6271,6 +6567,51 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.1.tgz",
+      "integrity": "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -6316,6 +6657,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -7215,6 +7562,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -7605,12 +7958,43 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "8.2.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "next-auth": "^5.0.0-beta.32",
     "prisma": "^6.19.3",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "recharts": "^3.0.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/api/nutrition/trends/route.test.ts
+++ b/src/app/api/nutrition/trends/route.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prismaMock, resetPrismaMock } from '@/test/prismaMock'
+
+vi.mock('@/lib/prisma', () => ({ prisma: prismaMock }))
+vi.mock('@/auth', () => ({ auth: vi.fn() }))
+
+import { auth } from '@/auth'
+import { GET } from './route'
+import { resolveTrendRange, type TrendRange } from '@/lib/dateRange'
+
+const mockAuth = vi.mocked(auth)
+
+function authedAs(userId: string) {
+  mockAuth.mockResolvedValue({ user: { id: userId } } as any)
+}
+
+function req(query: string): Request {
+  return new Request(`http://localhost/api/nutrition/trends${query}`)
+}
+
+beforeEach(() => {
+  resetPrismaMock()
+  mockAuth.mockReset()
+  prismaMock.dailyLog.findMany.mockResolvedValue([])
+})
+
+describe('GET /api/nutrition/trends', () => {
+  it('returns 401 when there is no session', async () => {
+    mockAuth.mockResolvedValue(null as any)
+
+    const res = await GET(req('?range=90d'))
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 on an invalid range value', async () => {
+    authedAs('user-1')
+
+    const res = await GET(req('?range=bogus'))
+
+    expect(res.status).toBe(400)
+  })
+
+  it('defaults to 90d when range is omitted', async () => {
+    authedAs('user-1')
+
+    const res = await GET(req(''))
+    const body = await res.json()
+
+    expect(body.data.range).toBe('90d')
+  })
+
+  it.each<TrendRange>(['90d', '6m', '1y'])(
+    'queries dailyLog with the correct where/orderBy/select for range=%s',
+    async (range) => {
+      authedAs('user-1')
+
+      const res = await GET(req(`?range=${range}`))
+      const body = await res.json()
+
+      const { start, end } = resolveTrendRange(range)
+
+      expect(prismaMock.dailyLog.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1', date: { gte: start, lte: end } },
+        orderBy: { date: 'asc' },
+        select: { date: true, weight: true, sleepHours: true, digestionRating: true },
+      })
+      expect(body.data.start).toBe(start)
+      expect(body.data.end).toBe(end)
+      expect(body.data.range).toBe(range)
+    }
+  )
+
+  it('returns the raw logs array from prisma in the response', async () => {
+    authedAs('user-1')
+    const logs = [{ date: '2026-08-01', weight: 180, sleepHours: 8, digestionRating: 4 }]
+    prismaMock.dailyLog.findMany.mockResolvedValue(logs)
+
+    const res = await GET(req('?range=90d'))
+    const body = await res.json()
+
+    expect(body.success).toBe(true)
+    expect(body.data.logs).toEqual(logs)
+  })
+})

--- a/src/app/api/nutrition/trends/route.ts
+++ b/src/app/api/nutrition/trends/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { prisma } from '@/lib/prisma'
+import { resolveTrendRange, type TrendRange } from '@/lib/dateRange'
+
+const VALID_RANGES: TrendRange[] = ['90d', '6m', '1y']
+
+export async function GET(request: Request) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const rawRange = searchParams.get('range')
+  const range = (rawRange || '90d') as TrendRange
+
+  if (!VALID_RANGES.includes(range)) {
+    return NextResponse.json(
+      { success: false, error: 'range must be one of 90d, 6m, 1y' },
+      { status: 400 }
+    )
+  }
+
+  const userId = session.user.id
+  const { start, end } = resolveTrendRange(range)
+
+  const logs = await prisma.dailyLog.findMany({
+    where: { userId, date: { gte: start, lte: end } },
+    orderBy: { date: 'asc' },
+    select: { date: true, weight: true, sleepHours: true, digestionRating: true },
+  })
+
+  return NextResponse.json({ success: true, data: { range, start, end, logs } })
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -34,6 +34,9 @@ export default function DashboardPage() {
               <Link href="/dashboard/calendar">
                 <Button variant="secondary">View calendar</Button>
               </Link>
+              <Link href="/dashboard/trends">
+                <Button variant="secondary">View trends</Button>
+              </Link>
               <Button variant="secondary" onClick={() => setShowLogForm(!showLogForm)}>
                 {showLogForm ? 'Cancel' : 'Log daily metrics'}
               </Button>

--- a/src/app/dashboard/trends/page.tsx
+++ b/src/app/dashboard/trends/page.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { apiClient, type TrendPoint } from '@/lib/api'
+import type { TrendRange } from '@/lib/dateRange'
+import { fromLbs, type WeightUnit } from '@/lib/weight'
+import Card from '@/components/ui/Card'
+import TrendRangeToggle from '@/components/trends/TrendRangeToggle'
+import TrendChart from '@/components/trends/TrendChart'
+
+export default function TrendsPage() {
+  const [selectedRange, setSelectedRange] = useState<TrendRange>('90d')
+  const [points, setPoints] = useState<TrendPoint[]>([])
+  const [weightUnit, setWeightUnit] = useState<WeightUnit>('lbs')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    apiClient.getTrends(selectedRange).then((res) => {
+      if (!cancelled && res.success) {
+        setPoints(res.data.logs)
+      }
+    }).finally(() => {
+      if (!cancelled) setLoading(false)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [selectedRange])
+
+  useEffect(() => {
+    apiClient.getGoal().then((res) => {
+      if (res.success && res.data.weightUnit) {
+        setWeightUnit(res.data.weightUnit)
+      }
+    })
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-cream-50 py-16">
+      <div className="max-w-6xl mx-auto px-6">
+        <div className="grid md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] gap-x-16 mb-10">
+          <div className="text-sm uppercase tracking-widest text-ink-900/40">Trends</div>
+          <div className="flex items-start justify-between">
+            <h1 className="font-display text-4xl text-ink-900">Your trends</h1>
+            <TrendRangeToggle selectedRange={selectedRange} onSelect={setSelectedRange} />
+          </div>
+        </div>
+
+        <div className="grid md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] gap-x-16">
+          <div />
+          <div>
+            {loading ? (
+              <p className="text-ink-900/60">Loading…</p>
+            ) : (
+              <div className="flex flex-col gap-10">
+                <div>
+                  <p className="text-sm uppercase tracking-widest text-ink-900/40 mb-3">Weight</p>
+                  <Card>
+                    <TrendChart
+                      data={points}
+                      dataKey="weight"
+                      color="rgba(232, 137, 74, 1)"
+                      valueTransform={(v) => fromLbs(v, weightUnit)}
+                      formatValue={(v) => `${Math.round(v * 10) / 10}${weightUnit}`}
+                    />
+                  </Card>
+                </div>
+
+                <div>
+                  <p className="text-sm uppercase tracking-widest text-ink-900/40 mb-3">Sleep</p>
+                  <Card>
+                    <TrendChart
+                      data={points}
+                      dataKey="sleepHours"
+                      color="rgba(90, 122, 82, 1)"
+                      formatValue={(v) => `${v}h`}
+                      yDomain={[0, 12]}
+                    />
+                  </Card>
+                </div>
+
+                <div>
+                  <p className="text-sm uppercase tracking-widest text-ink-900/40 mb-3">Digestion</p>
+                  <Card>
+                    <TrendChart
+                      data={points}
+                      dataKey="digestionRating"
+                      color="rgba(196, 97, 74, 1)"
+                      formatValue={(v) => String(v)}
+                      yDomain={[1, 5]}
+                    />
+                  </Card>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/DailyLogForm.tsx
+++ b/src/components/DailyLogForm.tsx
@@ -86,7 +86,7 @@ export default function DailyLogForm({ onLogSubmitted }: DailyLogFormProps) {
 
       <div>
         <label className="text-sm text-ink-900/60">
-          Yesterday's digestion rating
+          Yesterday&apos;s digestion rating
         </label>
         <div className="flex items-center gap-4 mt-2">
           {[1, 2, 3, 4, 5].map((rating) => (

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -43,6 +43,9 @@ export default function Navigation() {
               <Link href="/dashboard/calendar" className={navLinkClass}>
                 Calendar
               </Link>
+              <Link href="/dashboard/trends" className={navLinkClass}>
+                Trends
+              </Link>
             </div>
           </div>
           <div className="hidden sm:flex items-center gap-6">
@@ -131,6 +134,12 @@ export default function Navigation() {
               className="text-ink-900/70 hover:text-ink-900 block px-4 py-2 text-base"
             >
               Calendar
+            </Link>
+            <Link
+              href="/dashboard/trends"
+              className="text-ink-900/70 hover:text-ink-900 block px-4 py-2 text-base"
+            >
+              Trends
             </Link>
           </div>
           <div className="pt-4 pb-3 border-t border-ink-900/15">

--- a/src/components/plans/CreatePlanForm.tsx
+++ b/src/components/plans/CreatePlanForm.tsx
@@ -214,7 +214,7 @@ export default function CreatePlanForm({ onPlanCreated }: CreatePlanFormProps) {
       {/* Step 1: Weight Input */}
       {step === 1 && (
         <div className="space-y-6">
-          <h3 className="font-display text-xl text-ink-900">What's your current weight?</h3>
+          <h3 className="font-display text-xl text-ink-900">What&apos;s your current weight?</h3>
           <div className="space-y-4">
             <WeightInput
               label="Weight"
@@ -244,7 +244,7 @@ export default function CreatePlanForm({ onPlanCreated }: CreatePlanFormProps) {
       {/* Step 2: Goal Selection */}
       {step === 2 && (
         <div className="space-y-6">
-          <h3 className="font-display text-xl text-ink-900">What's your primary goal?</h3>
+          <h3 className="font-display text-xl text-ink-900">What&apos;s your primary goal?</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {goals.map((goal) => (
               <button

--- a/src/components/trends/TrendChart.tsx
+++ b/src/components/trends/TrendChart.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, type TooltipContentProps } from 'recharts'
+import type { TrendPoint } from '@/lib/api'
+
+interface TrendChartProps {
+  data: TrendPoint[]
+  dataKey: 'weight' | 'sleepHours' | 'digestionRating'
+  color: string // literal rgba() string, not a CSS var reference — Recharts SVG props need a concrete color
+  valueTransform?: (raw: number) => number // e.g. fromLbs for weight
+  formatValue?: (raw: number) => string
+  yDomain?: [number, number] // fixed for sleep/digestion; 'auto' for weight
+}
+
+const CHART_HEIGHT = 260
+
+function CustomTooltip({ active, payload, label, formatValue }: TooltipContentProps<number, string> & { formatValue?: (raw: number) => string }) {
+  if (!active || !payload || payload.length === 0) return null
+  const value = payload[0].value as number
+
+  return (
+    <div
+      style={{
+        backgroundColor: 'rgb(250 246 238)',
+        border: '1px solid rgba(35,31,26,0.15)',
+        padding: '6px 10px',
+        boxShadow: 'none',
+      }}
+    >
+      <p style={{ color: 'rgba(35,31,26,0.6)', fontSize: 12, margin: 0 }}>{label}</p>
+      <p style={{ color: 'rgb(35 31 26)', fontSize: 14, margin: 0 }}>
+        {formatValue ? formatValue(value) : value}
+      </p>
+    </div>
+  )
+}
+
+export default function TrendChart({ data, dataKey, color, valueTransform, formatValue, yDomain }: TrendChartProps) {
+  if (data.length === 0) {
+    return (
+      <div style={{ height: CHART_HEIGHT }} className="flex items-center justify-center">
+        <p className="text-ink-900/60">No data logged in this range yet</p>
+      </div>
+    )
+  }
+
+  const chartData = data.map((d) => ({
+    ...d,
+    [dataKey]: valueTransform ? valueTransform(d[dataKey]) : d[dataKey],
+  }))
+
+  return (
+    <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+      <LineChart data={chartData} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+        <CartesianGrid stroke="rgba(35,31,26,0.1)" />
+        <XAxis
+          dataKey="date"
+          axisLine={false}
+          tickLine={false}
+          tick={{ fill: 'rgba(35,31,26,0.4)', fontSize: 12 }}
+        />
+        <YAxis
+          axisLine={false}
+          tickLine={false}
+          domain={yDomain ?? ['auto', 'auto']}
+          tick={{ fill: 'rgba(35,31,26,0.4)', fontSize: 12 }}
+        />
+        <Tooltip content={(props) => <CustomTooltip {...props} formatValue={formatValue} />} />
+        <Line type="monotone" dataKey={dataKey} stroke={color} strokeWidth={2} dot={false} activeDot={{ r: 4 }} />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/src/components/trends/TrendRangeToggle.tsx
+++ b/src/components/trends/TrendRangeToggle.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { TREND_RANGES, TrendRange } from '@/lib/dateRange'
+
+interface TrendRangeToggleProps {
+  selectedRange: TrendRange
+  onSelect: (range: TrendRange) => void
+}
+
+export default function TrendRangeToggle({ selectedRange, onSelect }: TrendRangeToggleProps) {
+  return (
+    <div className="flex flex-wrap gap-3">
+      {TREND_RANGES.map((range) => (
+        <button
+          key={range.value}
+          onClick={() => onSelect(range.value)}
+          className={`min-h-[44px] px-5 py-3 border text-sm transition-colors ${
+            selectedRange === range.value
+              ? 'bg-ember-500 text-ink-900 border-ember-500'
+              : 'border-ink-900/25 text-ink-900 hover:border-ink-900/50'
+          }`}
+        >
+          {range.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -151,6 +151,22 @@ export interface CalendarMonth {
   days: CalendarDaySummary[];
 }
 
+export type TrendRange = '90d' | '6m' | '1y';
+
+export interface TrendPoint {
+  date: string;
+  weight: number;
+  sleepHours: number;
+  digestionRating: number;
+}
+
+export interface TrendsResponse {
+  range: TrendRange;
+  start: string;
+  end: string;
+  logs: TrendPoint[];
+}
+
 class ApiClient {
   private baseUrl: string;
 
@@ -294,6 +310,10 @@ class ApiClient {
   async getCalendarMonth(year: number, month: number): Promise<{ success: boolean; data: CalendarMonth }> {
     const monthParam = `${year}-${String(month).padStart(2, '0')}`;
     return this.request(`/nutrition/calendar?month=${monthParam}`);
+  }
+
+  async getTrends(range: TrendRange): Promise<{ success: boolean; data: TrendsResponse }> {
+    return this.request(`/nutrition/trends?range=${range}`);
   }
 
   async getGoal(): Promise<{ success: boolean; data: UserGoal }> {

--- a/src/lib/dateRange.test.ts
+++ b/src/lib/dateRange.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { daysAgo, monthsAgo, resolveTrendRange, TREND_RANGES } from './dateRange'
+
+describe('daysAgo', () => {
+  it('subtracts a basic number of days within the same month', () => {
+    expect(daysAgo(10, '2026-08-13')).toBe('2026-08-03')
+  })
+
+  it('subtracts days across a month boundary', () => {
+    expect(daysAgo(5, '2026-08-02')).toBe('2026-07-28')
+  })
+})
+
+describe('monthsAgo', () => {
+  it('subtracts a basic number of months with no clamp needed', () => {
+    expect(monthsAgo(2, '2026-08-15')).toBe('2026-06-15')
+  })
+
+  it('clamps to the target month last day when the source day does not exist there', () => {
+    expect(monthsAgo(1, '2026-03-31')).toBe('2026-02-28')
+  })
+
+  it('clamps to Feb 29 in a leap year', () => {
+    expect(monthsAgo(1, '2024-03-31')).toBe('2024-02-29')
+  })
+
+  it('crosses a year boundary when subtracting months', () => {
+    expect(monthsAgo(6, '2026-02-01')).toBe('2025-08-01')
+  })
+})
+
+describe('resolveTrendRange', () => {
+  const todayDate = '2026-08-13'
+
+  it('resolves 90d', () => {
+    expect(resolveTrendRange('90d', todayDate)).toEqual({ start: '2026-05-15', end: '2026-08-13' })
+  })
+
+  it('resolves 6m', () => {
+    expect(resolveTrendRange('6m', todayDate)).toEqual({ start: '2026-02-13', end: '2026-08-13' })
+  })
+
+  it('resolves 1y', () => {
+    expect(resolveTrendRange('1y', todayDate)).toEqual({ start: '2025-08-13', end: '2026-08-13' })
+  })
+
+  it('clamps correctly for 1y when the start lands on a leap-year Feb 29 boundary', () => {
+    // 12 months before 2028-02-29 (leap) -> 2027-02-29 does not exist -> clamp to 2027-02-28.
+    expect(resolveTrendRange('1y', '2028-02-29')).toEqual({ start: '2027-02-28', end: '2028-02-29' })
+  })
+
+  it('exposes exactly the three expected range presets', () => {
+    expect(TREND_RANGES).toEqual([
+      { value: '90d', label: '90 days' },
+      { value: '6m', label: '6 months' },
+      { value: '1y', label: '1 year' },
+    ])
+  })
+})

--- a/src/lib/dateRange.ts
+++ b/src/lib/dateRange.ts
@@ -1,0 +1,54 @@
+export type TrendRange = '90d' | '6m' | '1y'
+
+export const TREND_RANGES: { value: TrendRange; label: string }[] = [
+  { value: '90d', label: '90 days' },
+  { value: '6m', label: '6 months' },
+  { value: '1y', label: '1 year' },
+]
+
+/** Number of days in the given 1-indexed month/year, UTC-based. */
+function daysInMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate()
+}
+
+/** Subtracts `n` days from `from` (a YYYY-MM-DD string), returning a YYYY-MM-DD string. */
+export function daysAgo(n: number, from: string = new Date().toISOString().split('T')[0]): string {
+  const [year, month, day] = from.split('-').map(Number)
+  const result = new Date(Date.UTC(year, month - 1, day - n))
+  return result.toISOString().split('T')[0]
+}
+
+/**
+ * Subtracts `n` months from `from` (a YYYY-MM-DD string), clamping to the
+ * target month's last day if the source day-of-month doesn't exist there
+ * (e.g. monthsAgo(1, '2026-03-31') -> '2026-02-28').
+ */
+export function monthsAgo(n: number, from: string = new Date().toISOString().split('T')[0]): string {
+  const [year, month, day] = from.split('-').map(Number)
+  const zeroIndexed = month - 1 - n
+  const targetYear = year + Math.floor(zeroIndexed / 12)
+  const targetMonth = ((zeroIndexed % 12) + 12) % 12 + 1
+  const clampedDay = Math.min(day, daysInMonth(targetYear, targetMonth))
+  return new Date(Date.UTC(targetYear, targetMonth - 1, clampedDay)).toISOString().split('T')[0]
+}
+
+/** Resolves a TrendRange preset into a concrete { start, end } date pair. */
+export function resolveTrendRange(
+  range: TrendRange,
+  todayDate: string = new Date().toISOString().split('T')[0]
+): { start: string; end: string } {
+  const end = todayDate
+  let start: string
+  switch (range) {
+    case '90d':
+      start = daysAgo(90, end)
+      break
+    case '6m':
+      start = monthsAgo(6, end)
+      break
+    case '1y':
+      start = monthsAgo(12, end)
+      break
+  }
+  return { start, end }
+}


### PR DESCRIPTION
## Summary
- New `/dashboard/trends` page showing weight, sleep, and digestion as three separate Recharts line charts
- Selectable time range: 90 days / 6 months / 1 year, via `TrendRangeToggle`
- New `GET /api/nutrition/trends` endpoint backed by a `dateRange` utility for range resolution
- Weight chart respects the existing lbs/kg unit preference
- Navigation updated (desktop + mobile) with a `Trends` link and dashboard `View trends` button

## Test plan
- [x] `npm test` — 199/199 passing
- [x] Manual browser verification: chart rendering (weight/sleep/digestion, correct colors and data), all three range toggles, lbs/kg unit conversion, empty-state text ("No data logged in this range yet"), mobile responsive layout, zero console errors